### PR TITLE
ci(release): replace rm-dist with clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,6 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Close https://github.com/aereal/jsondiff/issues/37

`--rm-dist`: [goreleaser.com/deprecations#-rm-dist](https://goreleaser.com/deprecations/#-rm-dist)
