### PR TITLE
fix: release ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,6 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: CI
 on:
   pull_request:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
 ---
-
 builds:
-  -
-    main: ./cmd/jsondiff
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 ---
+version: 2
 builds:
+  - main: ./cmd/jsondiff
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Fixed CI to create release and build binaries. 

https://github.com/aereal/jsondiff/actions/runs/12820807416
![image](https://github.com/user-attachments/assets/290f7c15-44ed-4d2f-82d5-25061a34bf94)
