### PR TITLE
chore: change version of GoReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           cache: true
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I updated the version of GoReleaser in goreleaser/goreleaser-action.
Because there is a possible to break CI when has been release the new major version of GoReleaser.

document: https://github.com/goreleaser/goreleaser-action#workflow
related: https://github.com/aereal/jsondiff/pull/40
